### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/expressworks/jsonme.js
+++ b/expressworks/jsonme.js
@@ -1,11 +1,17 @@
 const express = require('express');
 const fs = require('fs');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const port = process.argv[2]; // Port passed as the first command-line argument
 const filename = process.argv[3];
 
-app.get('/books', (req, res) => {
+const booksLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs on /books
+});
+
+app.get('/books', booksLimiter, (req, res) => {
   fs.readFile(filename, 'utf8', (err, data) => {
     if (err) {
       res.status(500).json({ error: 'Error reading the file' });


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/nodeschool/security/code-scanning/1](https://github.com/Adam-Robson/nodeschool/security/code-scanning/1)

In general, the problem is fixed by introducing rate limiting middleware to the Express application so that expensive operations (like reading from the filesystem) cannot be triggered arbitrarily often by a single client or across all clients. The recommended approach in Node/Express is to use a well-known middleware such as `express-rate-limit` and apply it to the affected route(s) or the whole application.

For this specific code, the least intrusive fix is to install and use `express-rate-limit`, create a limiter instance with a reasonable window and `max` request count, and attach it only to the `/books` route so existing behavior is preserved except when the limit is exceeded. Concretely, in `expressworks/jsonme.js` we should: (1) add a `require('express-rate-limit')` after the existing `require` calls; (2) configure a limiter (for example, a 15-minute window with 100 requests) in a `const booksLimiter = rateLimit({ ... })`; and (3) update the `app.get('/books', (req, res) => { ... })` definition to insert `booksLimiter` as middleware: `app.get('/books', booksLimiter, (req, res) => { ... });`. No other logic inside the handler needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
