### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/expressworks/goodolform.js
+++ b/expressworks/goodolform.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
+const escape = require('escape-html');
 
 const app = express();
 
@@ -11,7 +12,7 @@ app.use(bodyParser.urlencoded({ extend: false }));
 app.post('/form', (req, res) => {
   const inputString = req.body.str;
   const returnString = inputString.split('').reverse().join('');
-  res.send(returnString);
+  res.send(escape(returnString));
 });
 
 app.listen(port, () => {

--- a/expressworks/package.json
+++ b/expressworks/package.json
@@ -11,6 +11,7 @@
     "body-parser": "latest",
     "express": "latest",
     "pug": "latest",
-    "stylus": "latest"
+    "stylus": "latest",
+    "escape-html": "^1.0.3"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/nodeschool/security/code-scanning/2](https://github.com/Adam-Robson/nodeschool/security/code-scanning/2)

To fix the reflected XSS issue, the user-controlled data (`req.body.str`) must be properly escaped/encoded before being sent in an HTTP response that may be interpreted as HTML. In Node/Express, a common approach is to escape HTML special characters (`&`, `<`, `>`, `"`, `'`, and `/`) using a well-known library such as `escape-html` before calling `res.send`.

The best low-impact fix, without changing existing functionality beyond securing the output, is:
- Import `escape-html` at the top of `expressworks/goodolform.js`.
- Apply `escape()` (from `escape-html`) to the string after reversing it, and send the escaped value with `res.send`. This preserves the current behavior (reversing the string and returning it) except that any HTML/JS markup is rendered harmless.

Concretely:
- In `expressworks/goodolform.js`, add `const escape = require('escape-html');` after the existing `require` statements.
- Change line 14 so that it sends `escape(returnString)` instead of `returnString` directly, or alternatively define `const safeReturnString = escape(returnString);` and send that. No other structural changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
